### PR TITLE
Fixed use in react import error

### DIFF
--- a/src/useEffectEvent.ts
+++ b/src/useEffectEvent.ts
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 const context = React.createContext(true)
 


### PR DESCRIPTION
### Description

Adds fix for error “Attempted import error: 'use' is not exported from 'react' (imported as 'React'). “ While building sanity io project having next-sanity packages. 

What changes are introduced?
- Reverses the changes introduced in the way React is being import in the project, which was introduced in the commit <https://github.com/sanity-io/use-effect-event/commit/a0f4ba0acd488655b3014fa171248bf41d510ddd>

Why are these changes introduced?
 - Sanity projects using next. Sanity package were failing while building with error message " Attempted import error: 'use' is not exported from 'react' (imported as 'React'). “. 

What issue(s) does this solve? (with link, if possible)
- Resolved issue with Link <https://github.com/sanity-io/use-effect-event/issues/58> . 


### What to review
- File src/useEffectEvent.ts 

What steps should the reviewer take in order to review?
- Just visual review of the code change.

What parts/flows of the application/packages/tooling is affected?
- None

### Testing
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test

- Made a change with how React is being imported locally directly in the module source code of use-effect-event, build the next.js sanity project and it build successfully.