### PR TITLE
docs: fix eslint-plugin-react-hooks url

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ function Page({url}) {
 
 ## Usage with `eslint-plugin-react-hooks`
 
-In order to use this hook with [`eslint-plugin-react-hooks`](npmjs.com/package/eslint-plugin-react-hooks), install `eslint-plugin-react-hooks@experimental`:
+In order to use this hook with [`eslint-plugin-react-hooks`](https://npmjs.com/package/eslint-plugin-react-hooks), install `eslint-plugin-react-hooks@experimental`:
 
 ```json
   "devDependencies": {


### PR DESCRIPTION
### Description

Fixes the link to the `eslint-plugin-react-hooks` package in the README.

### What to review

Confirm that the link now resolves to the npm package instead of a relative path.

### Testing

N/A